### PR TITLE
Remove a non-existing file from _CoqProject.

### DIFF
--- a/Stlc/_CoqProject
+++ b/Stlc/_CoqProject
@@ -1,7 +1,6 @@
 -R . Stlc
 Definitions.v
 Lemmas.v
-Classes.v
 Lec1.v
 Lec1_full.v
 Lec1_sol.v


### PR DESCRIPTION
`Classes.v` is not seen in the directory. Putting this file here would prevent other files from being compiled by `make`.