### PR TITLE
Add `eq_dec_refl` theorem for rewriting `x == x` to `left eq_refl`

### DIFF
--- a/Metalib/CoqEqDec.v
+++ b/Metalib/CoqEqDec.v
@@ -76,6 +76,16 @@ Class EqDec_eq (A : Type) :=
 Instance EqDec_eq_of_EqDec (A : Type) `(@EqDec A eq eq_equivalence) : EqDec_eq A.
 Proof. trivial. Defined.
 
+(** We can also provide a reflexivity theorem for rewriting with, since types
+    with decidable equality satisfy UIP/Axiom K and so we know that we can
+    rewrite the equality proof to `eq_refl`. *)
+
+Theorem eq_dec_refl {A : Type} `{EqDec_eq A} (x : A) : eq_dec x x = left eq_refl.
+Proof.
+  destruct (eq_dec x x); [|contradiction].
+  f_equal; apply (Eqdep_dec.UIP_dec eq_dec).
+Qed.
+
 (* ********************************************************************** *)
 (** * Decidable equality *)
 


### PR DESCRIPTION
It's a bit annoying, as came up at [the DeepSpec Summer School '17](https://deepspec.org/event/dsss17/), to have to `destruct (_ == _)` all the time even when the equality is obvious.  This allows us to `rewrite eq_dec_refl` to eliminate `x == x` expressions, instead of a `destruct` followed by a `contradiction`.

I don't think we can prove an analogous theorem `forall x y, x <> y -> (x == y) = right NEQ`, because I don't think there's a unique value for `NEQ : x <> y`, but one could write a tactic.