### PR TITLE
Add directory mapping for Metalib

### DIFF
--- a/Stlc/_CoqProject
+++ b/Stlc/_CoqProject
@@ -1,4 +1,5 @@
 -R . Stlc
+-R ../Metalib Metalib
 Definitions.v
 Lemmas.v
 Lec1.v


### PR DESCRIPTION
This change adds a physical-to-logical directory mapping for `Metalib`. I needed this for `make` in the `Stlc` directory to complete successfully.