### PR TITLE
Add Tutorial/_CoqProject

### DIFF
--- a/Tutorial/_CoqProject
+++ b/Tutorial/_CoqProject
@@ -1,0 +1,3 @@
+-R ../Metalib Metalib
+STLC.v
+STLCsol.v


### PR DESCRIPTION
This change adds the file `Tutorial/_CoqProject`, which allowed `make` in the `Tutorial` directory to complete successfully for me. There's a warning that I don't know what to do with:

```
$ make
coq_makefile -f _CoqProject -o CoqSrc.mk
Warning: no common logical root
Warning: in such case INSTALLDEFAULTROOT must be defined
Warning: the install-doc target is going to install files
Warning: in orphan_Top_Metalib
COQC STLC.v
COQC STLCsol.v
```