### PR TITLE
fix Stlc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,13 +16,13 @@ defaults: &defaults
       command: opam install .
   - run:
       name: Fsub
-      command: make -C Fsub
+      command: make -k -C Fsub
   - run:
       name: Tutorial
-      command: make -C Tutorial
+      command: make -k -C Tutorial
   - run:
       name: Stlc
-      command: make -C Stlc
+      command: make -k -C Stlc -B
 
 jobs:
   coq.8.10:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.v.d
 .coqdeps.d
 *.vo*
+*.v-e
 *.glob
 .*.aux
 *.v.d

--- a/Stlc/Connect.v
+++ b/Stlc/Connect.v
@@ -28,10 +28,9 @@
 
 Require Import String.
 Require Import Metalib.Metatheory.
-Require Import Stlc.Definitions.
-Require Import Stlc.Lemmas.
 
 Require Import Stlc.Nominal.
+Require Import Stlc.Lemmas.
 
 Import StlcNotations.
 

--- a/Stlc/Makefile
+++ b/Stlc/Makefile
@@ -34,8 +34,8 @@ zipclean:
 
 clean: Stlc.mk paperclean zipclean
 	make -f Stlc.mk clean
-	rm -f Stlc.mk
-	rm -f *.cmi *.cmo coqsplit
+	rm -f Stlc.mk*
+	rm -f *.cmi *.cmo coqsplit *_full* *_sol* *.v-e
 
 
 coq: $(GENCOQ) Stlc.mk


### PR DESCRIPTION
`Stlc.Definitions.app` was masked by `Coq.Init.Datatypes.app`, now fixed by reordering import.

`Stlc.v` in the folder works fine, but the "generated from Ott and fixed by sed" version fails:
> File "./Stlc.v", line 1, characters 15-41:
Error: Cannot find a physical path bound to logical path matching suffix
Metalib.Metalib.

If we no longer use `Stlc.v` from Ott, should we delete that rule from `Makefile` (as proposed here)?