### PR TITLE
Fix for deprecation warnings about hint locality; switch to lia from omega

### DIFF
--- a/Metalib/AssocList.v
+++ b/Metalib/AssocList.v
@@ -842,14 +842,17 @@ End BindsProperties2.
 (* *********************************************************************** *)
 (** * Hints *)
 
+#[global]
 Hint Resolve
   @app_assoc @app_nil_2 @map_app @dom_one @dom_cons @dom_app @dom_map : core.
 
+#[global]
 Hint Resolve
   @disjoint_sym_1 @disjoint_nil_1 @disjoint_one_2 @disjoint_cons_3
   @disjoint_app_3 @disjoint_map_2 @uniq_nil @uniq_push @uniq_one_1
   @uniq_cons_3 @uniq_app_4 @uniq_map_2 : core.
 
+#[global]
 Hint Resolve
   @binds_one_3 @binds_cons_2 @binds_cons_3 @binds_app_2 @binds_app_3
   @binds_map_2 : core.
@@ -1276,14 +1279,19 @@ End BindsDerived.
 (* *********************************************************************** *)
 (** * Hints *)
 
+#[global]
 Hint Resolve @nil_neq_one_mid @one_mid_neq_nil : core.
 
+#[global]
 Hint Resolve @uniq_insert_mid @uniq_map_app_l : core.
 
+#[global]
 Hint Immediate @uniq_remove_mid : core.
 
+#[global]
 Hint Resolve @binds_weaken : core.
 
+#[global]
 Hint Immediate @binds_remove_mid @binds_In : core. 
 
 

--- a/Metalib/CoqEqDec.v
+++ b/Metalib/CoqEqDec.v
@@ -15,8 +15,11 @@ Require Import Coq.Logic.Decidable.
 (* *********************************************************************** *)
 (** * Hints for [equiv] *)
 
+#[global]
 Hint Extern 0 (?x === ?x) => reflexivity : core. 
+#[global]
 Hint Extern 1 (_ === _) => (symmetry; trivial; fail) : core.
+#[global]
 Hint Extern 1 (_ =/= _) => (symmetry; trivial; fail) : core.
 
 

--- a/Metalib/CoqFSetDecide.v
+++ b/Metalib/CoqFSetDecide.v
@@ -451,6 +451,7 @@ the above form:
     (** Here is the tactic that will throw away hypotheses that
         are not useful (for the intended scope of the [fsetdec]
         tactic). *)
+    #[global]
     Hint Constructors FSet_elt_Prop FSet_Prop : FSet_Prop.
     Ltac discard_nonFSet :=
       repeat (
@@ -492,6 +493,7 @@ the above form:
 
     (** The hint database [FSet_decidability] will be given to
         the [push_neg] tactic from the module [Negation]. *)
+    #[global]
     Hint Resolve dec_In dec_eq : FSet_decidability.
 
     (** ** Normalizing Propositions About Equality
@@ -631,8 +633,10 @@ the above form:
     (** Here is the crux of the proof search.  Recursion through
         [intuition]!  (This will terminate if I correctly
         understand the behavior of [intuition].) *)
+    #[global]
     Hint Resolve E.eq_refl : FSet_Auto.
     (* SCW: to change to MSets, replace with this.
+    #[global]
     Hint Resolve (E.eq_equiv.(@Equivalence_Reflexive _ _)) : FSet_Auto. *)
     Ltac fsetdec_rec :=
       auto with FSet_Auto;

--- a/Metalib/CoqFSetInterface.v
+++ b/Metalib/CoqFSetInterface.v
@@ -258,12 +258,14 @@ Module Type WSfun (E : DecidableType).
 
   End Spec.
 
+  #[global]
   Hint Resolve mem_1 equal_1 subset_1 empty_1
     is_empty_1 choose_1 choose_2 add_1 add_2 remove_1
     remove_2 singleton_2 union_1 union_2 union_3
     inter_3 diff_3 fold_1 filter_3 for_all_1 exists_1
     partition_1 partition_2 elements_1 elements_3w
     : set.
+  #[global]
   Hint Immediate In_1 mem_2 equal_2 subset_2 is_empty_2 add_3
     remove_3 singleton_1 inter_1 inter_2 diff_1 diff_2
     filter_1 filter_2 for_all_2 exists_2 elements_2
@@ -340,7 +342,9 @@ Module Type Sfun (E : OrderedType).
 
   End Spec.
 
+  #[global]
   Hint Resolve elements_3 : set.
+  #[global]
   Hint Immediate
     min_elt_1 min_elt_2 min_elt_3 max_elt_1 max_elt_2 max_elt_3 : set.
 

--- a/Metalib/CoqMSetDecide.v
+++ b/Metalib/CoqMSetDecide.v
@@ -451,6 +451,7 @@ the above form:
     (** Here is the tactic that will throw away hypotheses that
         are not useful (for the intended scope of the [fsetdec]
         tactic). *)
+    #[global]
     Hint Constructors FSet_elt_Prop FSet_Prop : FSet_Prop.
     Ltac discard_nonFSet :=
       repeat (
@@ -492,6 +493,7 @@ the above form:
 
     (** The hint database [FSet_decidability] will be given to
         the [push_neg] tactic from the module [Negation]. *)
+    #[global]
     Hint Resolve dec_In dec_eq : FSet_decidability.
 
     (** ** Normalizing Propositions About Equality
@@ -632,6 +634,7 @@ the above form:
         [intuition]!  (This will terminate if I correctly
         understand the behavior of [intuition].) *)
     (* SCW: to change to MSets *)
+    #[global]
     Hint Resolve (E.eq_equiv.(@Equivalence_Reflexive _ _)) : FSet_Auto.
     Ltac fsetdec_rec :=
       auto with FSet_Auto;

--- a/Metalib/CoqMSetInterface.v
+++ b/Metalib/CoqMSetInterface.v
@@ -428,6 +428,7 @@ Module WRaw2SetsOn (E:DecidableType)(M:WRawSets E) <: WSetsOn E.
  Record t_ := Mkt {this :> M.t; is_ok : M.Ok this}.
  Definition t := t_.
  Arguments Mkt this {is_ok}.
+ #[global]
  Hint Resolve is_ok : typeclass_instances.
 
  Definition In (x : elt)(s : t) := M.In x s.(this).
@@ -870,9 +871,11 @@ Module MakeListOrdering (O:OrderedType).
         O.lt x y -> lt_list (x :: s) (y :: s')
     | lt_cons_eq : forall x y s s',
         O.eq x y -> lt_list s s' -> lt_list (x :: s) (y :: s').
+ #[global]
  Hint Constructors lt_list : core.
 
  Definition lt := lt_list.
+ #[global]
  Hint Unfold lt : core.
 
  Instance lt_strorder : StrictOrder lt.
@@ -919,6 +922,7 @@ Module MakeListOrdering (O:OrderedType).
   left; MO.order. right; rewrite <- E12; auto.
   left; MO.order. right; rewrite E12; auto.
  Qed.
+ #[global]
  Hint Resolve eq_cons : core.
 
  Lemma cons_CompSpec : forall c x1 x2 l1 l2, O.eq x1 x2 ->
@@ -926,6 +930,7 @@ Module MakeListOrdering (O:OrderedType).
  Proof.
   destruct c; simpl; inversion_clear 2; auto with relations.
  Qed.
+ #[global]
  Hint Resolve cons_CompSpec : core.
 
 End MakeListOrdering.

--- a/Metalib/CoqUniquenessTac.v
+++ b/Metalib/CoqUniquenessTac.v
@@ -10,7 +10,7 @@
 Require Import Coq.Lists.List.
 Require Import Coq.Logic.Eqdep_dec.
 
-Require Import Coq.omega.Omega.
+Require Import Lia.
 
 
 (* *********************************************************************** *)
@@ -105,6 +105,7 @@ Lemma eq_pair_dec : forall (A B : Type),
   (forall x y : A * B, {x = y} + {x <> y}).
 Proof. decide equality. Qed.
 
+#[global]
 Hint Resolve eq_unit_dec eq_pair_dec : eq_dec.
 
 

--- a/Metalib/CoqUniquenessTacEx.v
+++ b/Metalib/CoqUniquenessTacEx.v
@@ -7,7 +7,7 @@
 
 Require Import Coq.Arith.Peano_dec.
 Require Import Coq.Lists.SetoidList.
-Require Import Coq.omega.Omega.
+Require Import Lia.
 
 Require Import Metalib.CoqUniquenessTac.
 
@@ -18,6 +18,7 @@ Require Import Metalib.CoqUniquenessTac.
 (** The examples go through more smoothly if we declare [eq_nat_dec]
     as a hint. *)
 
+#[global]
 Hint Resolve eq_nat_dec : eq_dec.
 
 
@@ -30,7 +31,7 @@ Lemma le_unique : forall (x y : nat) (p q: x <= y), p = q.
 Proof.
   induction p using le_ind';
   uniqueness 1;
-  assert False by omega; intuition.
+  assert False by lia; intuition.
 
 Qed.
 

--- a/Metalib/FSetWeakNotin.v
+++ b/Metalib/FSetWeakNotin.v
@@ -146,6 +146,7 @@ End Lemmas.
 (* *********************************************************************** *)
 (** * Hints *)
 
+#[global]
 Hint Resolve
   @notin_empty_1 @notin_add_3 @notin_singleton_2 @notin_remove_2
   @notin_remove_3 @notin_remove_3' @notin_union_3 @notin_inter_2

--- a/Metalib/LibDefaultSimp.v
+++ b/Metalib/LibDefaultSimp.v
@@ -10,7 +10,7 @@
 
 Require Import Coq.Program.Equality.
 Require Import Coq.Program.Tactics.
-Require Import Coq.omega.Omega.
+Require Import Lia.
 
 
 (* *********************************************************************** *)
@@ -182,7 +182,7 @@ Ltac default_step :=
     | find_easy_inversion
     | destruct_exists
     | progress default_autorewrite
-    | solve [let H := fresh in assert (H : False) by omega; elim H]
+    | solve [let H := fresh in assert (H : False) by lia; elim H]
     ].
 
 (** [default_case_split] is similar to [default_step], except that the

--- a/Metalib/LibLNgen.v
+++ b/Metalib/LibLNgen.v
@@ -9,7 +9,7 @@
 
 Require Export Metalib.LibDefaultSimp.
 Require Import Metalib.Metatheory.
-Require Import Omega.
+Require Import Lia.
 
 
 (* ********************************************************************** *)
@@ -46,10 +46,10 @@ Ltac generalize_wrt x :=
     over should come first. *)
 
 Ltac apply_mutual_ind ind :=
-  match goal with 
-     [ |- (and _ _) ]  => apply ind 
-   | [ |- (prod _ _) ]  => apply ind 
-   | _ => 
+  match goal with
+     [ |- (and _ _) ]  => apply ind
+   | [ |- (prod _ _) ]  => apply ind
+   | _ =>
      let H := fresh in
      first [ (* apply ind
         | *) intros H; induction H using ind
@@ -127,18 +127,29 @@ Proof. fsetdec. Qed.
 (* *********************************************************************** *)
 (** * Hints *)
 
+#[global]
 Hint Resolve sym_eq : brute_force.
 
-Hint Extern 5 (_ = _ :> nat) => omega : brute_force.
-Hint Extern 5 (_ < _)        => omega : brute_force.
-Hint Extern 5 (_ <= _)       => omega : brute_force.
+#[global]
+Hint Extern 5 (_ = _ :> nat) => lia : brute_force.
+#[global]
+Hint Extern 5 (_ < _)        => lia : brute_force.
+#[global]
+Hint Extern 5 (_ <= _)       => lia : brute_force.
 
 Hint Rewrite @remove_union_distrib : lngen.
 
+#[global]
 Hint Resolve @Equal_union_compat : lngen.
+#[global]
 Hint Resolve @Subset_refl : lngen.
+#[global]
 Hint Resolve @Subset_empty_any : lngen.
+#[global]
 Hint Resolve @Subset_union_compat : lngen.
+#[global]
 Hint Resolve @Subset_union_left : lngen.
+#[global]
 Hint Resolve @Subset_union_right : lngen.
+#[global]
 Hint Resolve @Subset_union_lngen_open_upper : lngen.

--- a/Metalib/MSetWeakNotin.v
+++ b/Metalib/MSetWeakNotin.v
@@ -146,6 +146,7 @@ End Lemmas.
 (* *********************************************************************** *)
 (** * Hints *)
 
+#[global]
 Hint Resolve
   @notin_empty_1 @notin_add_3 @notin_singleton_2 @notin_remove_2
   @notin_remove_3 @notin_remove_3' @notin_union_3 @notin_inter_2
@@ -212,7 +213,9 @@ Ltac destruct_notin :=
     then tries some simple heuristics for solving the resulting
     goals. *)
 
+#[global]
 Hint Resolve (E.eq_equiv.(@Equivalence_Reflexive _ _)) : Auto_notin.
+#[global]
 Hint Immediate (E.eq_equiv.(@Equivalence_Symmetric _ _)) : Auto_notin.
 
 Ltac solve_notin :=

--- a/Metalib/Metatheory.v
+++ b/Metalib/Metatheory.v
@@ -224,14 +224,17 @@ Ltac hint_extern_solve_notin :=
                ];
   try tauto.
 
+#[global]
 Hint Extern 1 (_ <> _ :> _) => hint_extern_solve_notin : core.
 
+#[global]
 Hint Extern 1 (_ `notin` _) => hint_extern_solve_notin : core.
 
 (** The next block of hints are occasionally useful when reasoning
     about finite sets.  In some instances, they obviate the need to
     use [auto with set]. *)
 
+#[global]
 Hint Resolve
   AtomSetImpl.add_1 AtomSetImpl.add_2 AtomSetImpl.remove_1
   AtomSetImpl.remove_2 AtomSetImpl.singleton_2 AtomSetImpl.union_2

--- a/Metalib/MetatheoryAtom.v
+++ b/Metalib/MetatheoryAtom.v
@@ -18,7 +18,7 @@ Require Import Metalib.FSetExtra.
 Require Import Metalib.FSetWeakNotin.
 Require Import Metalib.LibTactics.
 
-Require Import Omega.
+Require Import Lia.
 
 (* ********************************************************************** *)
 (** * Defining atoms *)
@@ -44,6 +44,7 @@ Module Type ATOM <: UsualDecidableType.
 
   Parameter nat_of : atom -> nat.
 
+  #[global]
   Hint Resolve eq_dec : core.
 
   Include HasUsualEq <+ UsualIsEq <+ UsualIsEqOrig.
@@ -66,7 +67,7 @@ Module Atom : ATOM.
   Proof.
     induction x. auto with arith.
     induction y. auto with arith.
-      simpl. induction z. omega. auto with arith.
+      simpl. induction z. lia. auto with arith.
   Qed.
 
   Lemma nat_list_max : forall (xs : list nat),
@@ -85,7 +86,7 @@ Module Atom : ATOM.
     forall (xs : list nat), { n : nat | ~ List.In n xs }.
   Proof.
     intros xs. destruct (nat_list_max xs) as [x H].
-    exists (S x). intros J. lapply (H (S x)). omega. trivial.
+    exists (S x). intros J. lapply (H (S x)). lia. trivial.
   Qed.
 
   Definition fresh (l : list atom) :=


### PR DESCRIPTION
Copied over from https://github.com/k4rtik/lambda-qs/tree/main/vendor/metalib/src

---

PS: I don't know why this library needs Docker and a fixed version of Coq, but I was able to compile it very easily using dune on Coq v8.13.2 as linked above. If it's for the opam package, there is a way to create opam packages automatically using dune. I will leave this PR as a draft to hear if there is interest in a dune-based build, but this is all I needed to build locally (with warnings about `[fragile-hint-constr,automation]` that I could not fix easily):

```
kartik:~/Projects/GitHub/metalib$ cat dune-project 
(lang dune 2.8)
(name Metalib)
(version 0.1)
(using coq 0.3)
kartik:~/Projects/GitHub/metalib$ cat Metalib/dune 
(coq.theory
  (name Metalib))
```