### PR TITLE
Remove deprecated and unused stdlib dependency

### DIFF
--- a/Metalib/MetatheoryAtom.v
+++ b/Metalib/MetatheoryAtom.v
@@ -7,7 +7,6 @@
      Arthur Charg\'eraud *)
 
 Require Import Coq.Arith.Arith.
-Require Import Coq.Arith.Max.
 Require Import Coq.Classes.EquivDec.
 Require Import Coq.Lists.List.
 Require Import Coq.Structures.Equalities.


### PR DESCRIPTION
Coq 8.19 deprecated a few libraries. Fortunately the deprecated library `Coq.Arith.Max` was imported but not used in the code so it was as simple as removing it to make the code compatible with the latest Coq version.